### PR TITLE
remove log4j dependency and use slf4j interfaces instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,9 +139,9 @@
       <version>2.32</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.21</version>
     </dependency>
     <dependency>
       <groupId>org.tukaani</groupId>

--- a/src/main/java/edu/emory/mathcs/nlp/common/util/BinUtils.java
+++ b/src/main/java/edu/emory/mathcs/nlp/common/util/BinUtils.java
@@ -15,7 +15,8 @@
  */
 package edu.emory.mathcs.nlp.common.util;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 
@@ -29,7 +30,7 @@ public class BinUtils
 {
 	private BinUtils() {}
 	
-	public static final Logger LOG = Logger.getLogger(BinUtils.class);
+	public static final Logger LOG = LoggerFactory.getLogger(BinUtils.class);
 	
 	/** Initializes arguments using args4j. */
 	static public void initArgs(String[] args, Object bean)


### PR DESCRIPTION
Please use slf4j interfaces for logging so that users can use logger implementation of their choice.
